### PR TITLE
Allow to request certs without OCSP Must-Staple extension

### DIFF
--- a/manifests/certificate.pp
+++ b/manifests/certificate.pp
@@ -29,6 +29,9 @@
 # [*dh_param_size*]
 #   dh parameter size, defaults to $::acme::dh_param_size
 #
+# [*ocsp_must_staple*]
+#   request certificate with OCSP Must-Staple exctension, defaults to $::acme::ocsp_must_staple
+#
 # === Examples
 #   ::acme::certificate( 'foo.example.com' :
 #   }
@@ -36,11 +39,12 @@
 define acme::certificate (
   $use_account,
   $use_profile,
-  $domain         = $name,
-  $renew_days     = $::acme::params::renew_days,
-  $letsencrypt_ca = undef,
-  $acme_host      = $::acme::acme_host,
-  $dh_param_size  = $::acme::dh_param_size,
+  $domain           = $name,
+  $renew_days       = $::acme::params::renew_days,
+  $letsencrypt_ca   = undef,
+  $acme_host        = $::acme::acme_host,
+  $dh_param_size    = $::acme::dh_param_size,
+  $ocsp_must_staple = $::acme::ocsp_must_staple
 ){
   validate_integer($dh_param_size)
   validate_string($acme_host)
@@ -58,12 +62,13 @@ define acme::certificate (
 
   # Generate CSRs.
   ::acme::csr { $domain:
-    use_account    => $use_account,
-    use_profile    => $use_profile,
-    acme_host      => $acme_host,
-    dh_param_size  => $dh_param_size,
-    renew_days     => $renew_days,
-    letsencrypt_ca => $letsencrypt_ca,
+    use_account      => $use_account,
+    use_profile      => $use_profile,
+    acme_host        => $acme_host,
+    dh_param_size    => $dh_param_size,
+    ocsp_must_staple => $ocsp_must_staple,
+    renew_days       => $renew_days,
+    letsencrypt_ca   => $letsencrypt_ca,
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,6 +40,9 @@
 # [*dh_param_size*]
 #   dh parameter size, defaults to 2048
 #
+# [*ocsp_must_staple*]
+#   Request certificats with OCSP Must-Staple extension, defaults to true
+#
 # [*manage_packages*]
 #   install necessary packages, mainly git
 #
@@ -60,6 +63,7 @@ class acme (
   $letsencrypt_ca    = $::acme::params::letsencrypt_ca,
   $letsencrypt_proxy = undef,
   $dh_param_size     = $::acme::params::dh_param_size,
+  $ocsp_must_staple  = $::acme::params::ocsp_must_staple,
   $manage_packages   = $::acme::params::manage_packages,
 ) inherits ::acme::params {
 
@@ -103,9 +107,10 @@ class acme (
   $certificates.each |$domain, $config| {
     # Merge domain params with module params.
     $options = deep_merge({
-      domain        => $domain,
-      acme_host     => $acme_host,
-      dh_param_size => $dh_param_size,
+      domain           => $domain,
+      acme_host        => $acme_host,
+      dh_param_size    => $dh_param_size,
+      ocsp_must_staple => $ocsp_must_staple,
     },$config)
     # Create the certificate resource.
     ::acme::certificate { $domain: * => $options }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -102,11 +102,11 @@ class acme (
   # Generate CSRs.
   $certificates.each |$domain, $config| {
     # Merge domain params with module params.
-    $options = deep_merge($config,{
+    $options = deep_merge({
       domain        => $domain,
       acme_host     => $acme_host,
       dh_param_size => $dh_param_size,
-    })
+    },$config)
     # Create the certificate resource.
     ::acme::certificate { $domain: * => $options }
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -26,6 +26,7 @@ class acme::params {
 
   # Cert defaults
   $dh_param_size = 2048
+  $ocsp_must_staple = true
 
   # Module defaults
   $manage_packages = true

--- a/manifests/request.pp
+++ b/manifests/request.pp
@@ -24,10 +24,11 @@ define acme::request (
   $csr,
   $use_account,
   $use_profile,
-  $renew_days     = $::acme::params::renew_days,
-  $letsencrypt_ca = undef,
-  $domain         = $name,
-  $altnames       = undef,
+  $renew_days       = $::acme::params::renew_days,
+  $letsencrypt_ca   = undef,
+  $domain           = $name,
+  $altnames         = undef,
+  $ocsp_must_staple = true,
 ) {
   require ::acme::params
 
@@ -90,6 +91,13 @@ define acme::request (
   }
 
   $account_conf_file = "${acct_dir}/${account_email}/account_${_letsencrypt_ca}.conf"
+
+  # Add ocsp if must-staple is requested
+  if ($ocsp_must_staple) {
+    $_ocsp = '--ocsp'
+  } else {
+    $_ocsp = ''
+  }
 
   # Collect options for "supported" hooks.
   if ($challengetype == 'dns-01') {
@@ -203,7 +211,7 @@ define acme::request (
     "--home ${$acme_dir}",
     '--keylength 4096',
     "--accountconf ${account_conf_file}",
-    '--ocsp',
+    $_ocsp,
     "--csr ${csr_file}",
     "--certpath ${crt_file}",
     "--capath ${chain_file}",
@@ -226,7 +234,7 @@ define acme::request (
     "--home ${$acme_dir}",
     '--keylength 4096',
     "--accountconf ${account_conf_file}",
-    '--ocsp',
+    $_ocsp,
     "--csr ${csr_file}",
     "--certpath ${crt_file}",
     "--capath ${chain_file}",

--- a/templates/cert.cnf.erb
+++ b/templates/cert.cnf.erb
@@ -11,9 +11,7 @@ default_md              = sha256
 default_keyfile         = privkey.pem
 distinguished_name      = req_distinguished_name
 prompt                  = no
-<% if @req_ext -%>
 req_extensions          = v3_req
-<% end -%>
 
 [ req_distinguished_name ]
 commonName                      = <%= @domain %>
@@ -36,12 +34,16 @@ organizationalUnitName          = <%= @unit %>
 emailAddress                    = <%= @email %>
 <% end -%>
 
-<% if @req_ext -%>
 [ v3_req ]
+<% if @has_san -%>
 subjectAltName = @alt_names
+<% end -%>
 keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+<% if @ocsp_must_staple -%>
 1.3.6.1.5.5.7.1.24 = DER:30:03:02:01:05
+<% end -%>
 
+<% if @has_san -%>
 [ alt_names ]
 <%- i=1 -%>
 <% @subject_alt_names.each do |val| -%>


### PR DESCRIPTION
This change adds a $ocsp_must_staple flag (defaults to true like before)
that allows to generate certificate requests that don't request the
OCSP Must-Staple extension.

This is useful for services that don't (yet) support OCSP stapling,
since compliant clients will otherwise reject the certificate if stapled
OCSP information is not provided by the service.

Furthermore, with this change, the keyUsage extension entries are now
always requested, even if no SAN are available.

--

You might want to review this with --ignore-space-change because of the aligned arrows / assignments.