### PR TITLE
Support openssl >= 1.1.0

### DIFF
--- a/manifests/request/handler.pp
+++ b/manifests/request/handler.pp
@@ -184,6 +184,9 @@ class acme::request::handler(
     }
   }
 
+  # needed for the openssl ocsp -header flag
+  $openssl_before_110 = versioncmp($::openssl_version, '1.1.0') < 0
+
   file { $ocsp_request:
     ensure  => file,
     owner   => 'root',

--- a/templates/get_certificate_ocsp.sh.erb
+++ b/templates/get_certificate_ocsp.sh.erb
@@ -23,7 +23,11 @@ openssl ocsp -noverify -issuer "${2}" \
 <% else -%>
 openssl ocsp -noverify -issuer "${2}" \
     -cert "${1}" \
+<% if @openssl_before_110 -%>
     -header Host "${OCSPHOST}" \
+<% else -%>
+    -header Host="${OCSPHOST}" \
+<% end -%>
     -url "${OCSPURL}" -respout "${3}.new"
 
 <% end -%>


### PR DESCRIPTION
In openssl 1.1.0, the ocsp command's header flag changed from (the
undocumented format) "-header key value" to "-header key=value".
(see https://github.com/openssl/openssl/commit/7e1b7485706c2b11091b5fa897fe496a2faa56cc)

This change uses the openssl_version fact to determine which format to
use in the deployed script.