### PR TITLE
Make sure acme_git_url is passed to ::acme::setup::puppetmaster class

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -76,6 +76,7 @@ class acme (
   # Is this the host to sign CSRs?
   if ($::fqdn == $acme_host) {
     class { '::acme::setup::puppetmaster' :
+      acme_git_url    => $acme_git_url,
       manage_packages => $manage_packages,
     }
 

--- a/manifests/setup/puppetmaster.pp
+++ b/manifests/setup/puppetmaster.pp
@@ -3,6 +3,7 @@
 # setup all necessary directories and groups
 #
 class acme::setup::puppetmaster (
+  $acme_git_url,
   $manage_packages  = $::acme::params::manage_packages,
   $acme_install_dir = $::acme::params::acme_install_dir,
   $csr_dir          = $::acme::params::csr_dir,


### PR DESCRIPTION
This pull request implements a fix that makes sure that a custom acme_git_url is passed to the acme::setup::puppetmaster class.