### PR TITLE
Fix facts lookup on Puppet 5

### DIFF
--- a/lib/facter/acme_crt.rb
+++ b/lib/facter/acme_crt.rb
@@ -1,5 +1,5 @@
 require 'facter'
-crt_domains = Dir['/etc/acme.sh/results/*.pem'].map { |a| a.gsub(%r{\.pem$}, '').gsub(%r{^.*/}, '') }
+crt_domains = Dir['/etc/acme.sh/results/*.pem'].map { |a| File.basename(a, '.pem') }
 
 Facter.add(:acme_crts) do
   setcode do

--- a/lib/facter/acme_crts.rb
+++ b/lib/facter/acme_crts.rb
@@ -1,6 +1,6 @@
 require 'facter'
 
-crt_domains = Dir['/etc/acme.sh/results/*.pem'].map { |a| a.gsub(%r{\.pem$}, '').gsub(%r{^.*/}, '') }
+crt_domains = Dir['/etc/acme.sh/results/*.pem'].map { |a| File.basename(a, '.pem') }
 
 crt_domains.each do |crt_domain|
   Facter.add('acme_crt_' + crt_domain.gsub(/[.-]/, '_')) do

--- a/lib/facter/acme_crts.rb
+++ b/lib/facter/acme_crts.rb
@@ -3,7 +3,7 @@ require 'facter'
 crt_domains = Dir['/etc/acme.sh/results/*.pem'].map { |a| a.gsub(%r{\.pem$}, '').gsub(%r{^.*/}, '') }
 
 crt_domains.each do |crt_domain|
-  Facter.add('acme_crt_' + crt_domain.gsub('.', '_').gsub('-', '_')) do
+  Facter.add('acme_crt_' + crt_domain.gsub(/[.-]/, '_')) do
     setcode do
       crt = File.read("/etc/acme.sh/results/#{crt_domain}.pem")
       crt.strip
@@ -12,7 +12,7 @@ crt_domains.each do |crt_domain|
 end
 
 crt_domains.each do |crt_domain|
-  Facter.add('acme_ca_' + crt_domain.gsub('.', '_').gsub('-', '_')) do
+  Facter.add('acme_ca_' + crt_domain.gsub(/[.-]/, '_')) do
     setcode do
       ca = File.read("/etc/acme.sh/results/#{crt_domain}.ca")
       ca.strip

--- a/lib/facter/acme_csr.rb
+++ b/lib/facter/acme_csr.rb
@@ -9,7 +9,7 @@ Facter.add(:acme_csrs) do
 end
 
 csr_domains.each do |csr_domain|
-  Facter.add('acme_csr_' + csr_domain.gsub('.', '_').gsub('-', '_')) do
+  Facter.add('acme_csr_' + csr_domain.gsub(/[.-]/, '_')) do
     setcode do
       csr = File.read("/etc/acme.sh/certs/#{csr_domain}/cert.csr")
       csr

--- a/lib/facter/acme_csr.rb
+++ b/lib/facter/acme_csr.rb
@@ -1,6 +1,6 @@
 require 'facter'
 
-csr_domains = Dir['/etc/acme.sh/certs/*/cert.csr'].map { |a| a.gsub(%r{\/cert\.csr$}, '').gsub(%r{^.*/}, '') }
+csr_domains = Dir['/etc/acme.sh/certs/*/cert.csr'].map { |a| File.basename(File.dirname(a)) }
 
 Facter.add(:acme_csrs) do
   setcode do

--- a/manifests/csr.pp
+++ b/manifests/csr.pp
@@ -186,7 +186,7 @@ define acme::csr(
     require => X509_request[$csr_file],
   }
 
-  $domain_rep = regsubst(regsubst($domain, '\.', '_', 'G'),'-', '_', 'G')
+  $domain_rep = regsubst($domain, /[.-]/, '_', 'G')
   $csr_content = pick_default(getvar("::acme_csr_${domain_rep}"), '')
   if ($csr_content =~ /CERTIFICATE REQUEST/) {
     @@acme::request { $domain:

--- a/manifests/request/crt.pp
+++ b/manifests/request/crt.pp
@@ -21,13 +21,13 @@ define acme::request::crt(
 
   $domain_rep = regsubst(regsubst($domain, '\.', '_', 'G'),'-', '_', 'G')
 
-  $crt = pick_default($facts.get("acme_crt_${domain_rep}"), '')
+  $crt = pick_default($facts["acme_crt_${domain_rep}"], '')
   notify { "cert for ${domain} from ${result_crt_file} contents: ${crt}": loglevel => debug }
 
   # special handling for ocsp stuff (binary data)
   $ocsp = base64('encode', file_or_empty_string($ocsp_file))
 
-  $chain = pick_default($facts.get("acme_ca_${domain_rep}"), '')
+  $chain = pick_default($facts["acme_ca_${domain_rep}"], '')
   notify { "chain for ${domain} from ${le_chain_file} contents: ${chain}": loglevel => debug }
 
   if ($crt =~ /BEGIN CERTIFICATE/) {

--- a/manifests/request/crt.pp
+++ b/manifests/request/crt.pp
@@ -19,7 +19,7 @@ define acme::request::crt(
   $le_chain_file = "${acme_dir}/${domain}/ca.cer"
   $le_fullchain_file = "${acme_dir}/${domain}/fullchain.cer"
 
-  $domain_rep = regsubst(regsubst($domain, '\.', '_', 'G'),'-', '_', 'G')
+  $domain_rep = regsubst($domain, /[.-]/, '_', 'G')
 
   $crt = pick_default($facts["acme_crt_${domain_rep}"], '')
   notify { "cert for ${domain} from ${result_crt_file} contents: ${crt}": loglevel => debug }


### PR DESCRIPTION
Use $facts[] lookup instead of the .get function introduced in puppet6. It is not needed here anyway, since we do not want to dig into nested facts.

Fixes #17

This PR includes some simplifications of the chained replacements and filename mangling.