### PR TITLE
Add support for External Account Binding (EAB)

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,26 @@ Note that the CA URL must be configured and the CA name must be whitelisted on t
     }
 ~~~
 
+Some private CAs (e.g. HashiCorp Vault / OpenBao PKI, ZeroSSL) require
+[External Account Binding (EAB)](https://datatracker.ietf.org/doc/html/rfc8555#section-7.3.4)
+during account registration. Provide the `kid` and `hmac_key` obtained from the
+CA via the `ca_eab` parameter, keyed by the CA name:
+
+~~~puppet
+    Class { 'acme':
+      default_ca   => 'letsencrypt',
+      ca_config    => { private_ca123 => 'https://ca.example.com/v1/pki/acme/directory' },
+      ca_eab       => { private_ca123 => { kid => 'abc123', hmac_key => 'base64encodedhmac' } },
+      ca_whitelist => [ 'private_ca123', 'letsencrypt' ],
+      ...
+    }
+~~~
+
+Note that acme.sh only accepts EAB credentials on the command line, so the
+`hmac_key` will appear in the account registration Exec resource (and therefore
+in Puppet reports). EAB credentials are frequently single-use, so this works
+best for CAs configured with a single account per CA.
+
 ### Testing and Debugging
 
 For testing purposes you should use a test CA, such as `letsencrypt_test`. Otherwise

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -124,6 +124,22 @@ Data type: `Optional[Hash[Pattern[/^[a-z0-9_-]+$/], Stdlib::HTTPSUrl]]`
 A hash that contains the name and URL of one of more custom CAs.
 Note that the name must not conflict with the default CAs.
 
+##### `ca_eab`
+
+Data type: `Optional[Hash[Pattern[/^[a-z0-9_-]+$/], Struct[{ kid => String[1], hmac_key => String[1] }]]]`
+
+A hash that provides External Account Binding (EAB) credentials for one or
+more custom CAs that require them during account registration (RFC 8555).
+The hash is keyed by CA name (matching a key in `$ca_config`), and each
+value must be a hash with `kid` and `hmac_key`. Example:
+`{ private_ca123 => { kid => 'abc123', hmac_key => 'base64hmac' } }`.
+Note: acme.sh only accepts EAB credentials on the command line, so the
+`hmac_key` will be visible in the account registration Exec resource
+(and thus in Puppet reports). EAB credentials are often single-use, so
+this is primarily useful for CAs with a single account per CA.
+
+Default value: `undef`
+
 ##### `ca_whitelist`
 
 Data type: `Array`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,6 +43,17 @@
 #   A hash that contains the name and URL of one of more custom CAs.
 #   Note that the name must not conflict with the default CAs.
 #
+# @param ca_eab
+#   A hash that provides External Account Binding (EAB) credentials for one or
+#   more custom CAs that require them during account registration (RFC 8555).
+#   The hash is keyed by CA name (matching a key in `$ca_config`), and each
+#   value must be a hash with `kid` and `hmac_key`. Example:
+#   `{ private_ca123 => { kid => 'abc123', hmac_key => 'base64hmac' } }`.
+#   Note: acme.sh only accepts EAB credentials on the command line, so the
+#   `hmac_key` will be visible in the account registration Exec resource
+#   (and thus in Puppet reports). EAB credentials are often single-use, so
+#   this is primarily useful for CAs with a single account per CA.
+#
 # @param ca_whitelist
 #   Specifies the CAs that may be used on `$acme_host`. The module will register
 #   any account specified in `$accounts` with all specified CAs. This ensures that
@@ -192,6 +203,7 @@ class acme (
   String $user,
   # optional parameters
   Optional[Hash[Pattern[/^[a-z0-9_-]+$/], Stdlib::HTTPSUrl]] $ca_config,
+  Optional[Hash[Pattern[/^[a-z0-9_-]+$/], Struct[{ kid => String[1], hmac_key => String[1] }]]] $ca_eab = undef,
   Optional[String] $default_account = undef,
   Optional[String] $default_profile = undef,
   Optional[String] $proxy = undef,

--- a/manifests/request/handler.pp
+++ b/manifests/request/handler.pp
@@ -47,6 +47,18 @@ class acme::request::handler {
         $ca_url = $acme_ca
       }
 
+      # Extract External Account Binding (EAB) credentials for CAs that
+      # require them during registration (RFC 8555). Only applied to the
+      # "--registeraccount" call below, as EAB is used when binding the
+      # account to a pre-authorized identity on the CA.
+      if ($acme::ca_eab != undef) and ($acme_ca in $acme::ca_eab) {
+        $eab_kid = $acme::ca_eab[$acme_ca]['kid']
+        $eab_hmac_key = $acme::ca_eab[$acme_ca]['hmac_key']
+        $eab_args = ["--eab-kid \'${eab_kid}\'", "--eab-hmac-key \'${eab_hmac_key}\'"]
+      } else {
+        $eab_args = []
+      }
+
       # Handle switching CAs with different account keys.
       $account_key_file = "${account_dir}/private_${acme_ca_compat}.key"
       $account_conf_file = "${account_dir}/account_${acme_ca_compat}.conf"
@@ -116,6 +128,7 @@ class acme::request::handler {
           "--home \'${acme::acme_dir}\'",
           "--accountconf ${account_conf_file}",
           "--server ${ca_url}",
+        ] + $eab_args + [
           '>/dev/null',
           '&&',
           "touch \'${account_registered_file}\'",


### PR DESCRIPTION
## Summary

Adds a new `ca_eab` parameter so accounts can be registered against ACME CAs that require **External Account Binding** (EAB, RFC 8555 section 7.3.4) - e.g. HashiCorp Vault / OpenBao PKI, ZeroSSL.

Previously the account registration command in `acme::request::handler` was fixed and offered no way to pass `--eab-kid`/`--eab-hmac-key`, so registration against such CAs was rejected.

## Details

- New `ca_eab` param on the `acme` class: `Optional[Hash[Pattern[/^[a-z0-9_-]+$/], Struct[{ kid => String[1], hmac_key => String[1] }]]]`, keyed by CA name (matching a key in `ca_config`).
- When a whitelisted CA has EAB credentials, `--eab-kid`/`--eab-hmac-key` are appended to the `--registeraccount` call for that CA only.
- Backwards compatible: defaults to `undef`, no behaviour change when unset.
- README + REFERENCE updated. `pdk validate` passes clean.

## Example

```puppet
class { 'acme':
  ca_config    => { vault_ca => 'https://vault.example.com/v1/pki/acme/directory' },
  ca_eab       => { vault_ca => { kid => 'abc123', hmac_key => 'base64hmac' } },
  ca_whitelist => ['vault_ca'],
}
```

## Note

acme.sh only accepts EAB credentials on the command line, so the `hmac_key` will appear in the registration Exec resource (and Puppet reports). This is documented on the parameter. EAB credentials are frequently single-use, so this suits CAs with a single account per CA.